### PR TITLE
Fix fzf arguments handling

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -78,7 +78,7 @@
     (let ((buf (get-buffer-create "*fzf*")))
       (split-window-vertically fzf/window-height)
       (if fzf/args
-          (make-term "fzf" fzf/executable nil fzf/args)
+          (apply 'make-term "fzf" fzf/executable nil (split-string fzf/args " "))
         (make-term "fzf" fzf/executable))
       (switch-to-buffer buf)
       (term-char-mode)


### PR DESCRIPTION
If ``fzf/args`` is something like "-x --color=no" the plugin refuses to work. This tiny patch fixes the issue for me. 