### PR TITLE
Search in current directory if not in project

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -95,7 +95,10 @@
   "Starts a fzf session."
   (interactive)
   (if (fboundp #'projectile-project-root)
-      (fzf/start (projectile-project-root))
+      (fzf/start (condition-case err
+                     (projectile-project-root)
+                   (error
+                    default-directory)))
     (fzf/start default-directory)))
 
 ;;;###autoload


### PR DESCRIPTION
This patch fixes wrong (really, don't think it was made by design) plugin behavior when projectile is installed but fzf is called outside a project. In this case projectile returns an error and fzf fails to start. Applying this patch will make fzf to search in the current buffer directory in case projectile-project-root function returns error.