### PR TITLE
Bugfix: allow selection of paths wider than Emacs window

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -85,6 +85,7 @@
       ;; disable various settings known to cause artifacts, see #1 for more details
       (setq-local scroll-margin 0)
       (setq-local scroll-conservatively 0)
+      (setq-local term-suppress-hard-newline t) ;for paths wider than the window
       (face-remap-add-relative 'mode-line '(:box nil))
 
       (term-char-mode)


### PR DESCRIPTION
Previously, when fzf finished and printed to the terminal buffer a path
that was wider than the Emacs window, term mode was adding a newline at
each place where the path reached the right edge of the window and
needed to wrap to the next line.  With this change, term mode does not
add any newlines, so fzf can safely deliver long paths back to Emacs.