### PR TITLE
Removed buggy line-break behavior on emacs over terminal

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -90,6 +90,7 @@
       (make-term "fzf" fzf/executable))
     (switch-to-buffer buf)
     (linum-mode 0)
+    ;;(set-window-margins nil 1)
 
     ;; disable various settings known to cause artifacts, see #1 for more details
     (setq-local scroll-margin 0)
@@ -112,10 +113,10 @@
     (fzf/start default-directory)))
 
 ;;;###autoload
-(defun fzf-directory (directory)
+(defun fzf-directory ()
   "Starts a fzf session at the specified directory."
-  (interactive "D")
-  (fzf/start directory))
+  (interactive)
+  (fzf/start (ido-read-directory-name "Directory: ")))
 
 (provide 'fzf)
 ;;; fzf.el ends here

--- a/fzf.el
+++ b/fzf.el
@@ -54,9 +54,9 @@
   :type 'string
   :group 'fzf)
 
-(defcustom fzf/args "-x --color bw --print-query"
+(defcustom fzf/args '("-x --color bw --print-query")
   "Additional arguments to pass into fzf."
-  :type 'string
+  :type 'list
   :group 'fzf)
 
 (defcustom fzf/position-bottom t
@@ -86,7 +86,7 @@
     (split-window-vertically window-height)
     (when fzf/position-bottom (other-window 1))
     (if fzf/args
-        (apply 'make-term "fzf" fzf/executable nil (split-string fzf/args " "))
+        (apply 'make-term "fzf" fzf/executable nil fzf/args)
       (make-term "fzf" fzf/executable))
     (switch-to-buffer buf)
     (linum-mode 0)

--- a/fzf.el
+++ b/fzf.el
@@ -90,7 +90,6 @@
       (make-term "fzf" fzf/executable))
     (switch-to-buffer buf)
     (linum-mode 0)
-    (set-window-margins nil 1)
 
     ;; disable various settings known to cause artifacts, see #1 for more details
     (setq-local scroll-margin 0)


### PR DESCRIPTION
`(set-window-margins nil 1)`
Was causing unexpected and buggy parsing of line breaks over the output of fzf: https://i.imgur.com/UC0EUKq.png