### PR TITLE
READY FOR REVIEW - Disable visual-line-mode for FZF buffers

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -100,6 +100,7 @@
       (make-term "fzf" fzf/executable))
     (switch-to-buffer buf)
     (linum-mode 0)
+    (visual-line-mode 0)
 
     ;; disable various settings known to cause artifacts, see #1 for more details
     (setq-local scroll-margin 0)


### PR DESCRIPTION
`visual-line-mode` seems incompatible with term buffers, specifically
that used by FZF. Some users enable the mode globally (e.g., via
`global-visual-line-mode`). This explicitly turns off the mode for
FZF buffers.

Fixes #28.