### PR TITLE
Fix fzf-git-files works fine in eshell buffer.(#35)

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -120,9 +120,9 @@
       (fzf-directory))))
 
 (defun fzf/git-files ()
-  (let ((process-environment
-         (cons (concat "FZF_DEFAULT_COMMAND=git ls-files")
-               process-environment))
+  (let ((for-eshell-environment (kill-local-variable 'process-environment))
+        (process-environment (cons "FZF_DEFAULT_COMMAND=git ls-files"
+                                   process-environment))
         (path (locate-dominating-file default-directory ".git")))
     (if path
         (fzf/start path)


### PR DESCRIPTION
I found simple solution.
Making process-environment global variable locally was enough for fzf-git-files working fine in eshell buffer.

This would be also helpful for any other buffers which making process-environment local variable as well.

Thanks.