### PR TITLE
Generalize fzf.el into a completion engine with fzf 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,44 @@ fzf.el can be installed through [MELPA][2].
 
 # usage
 
-`M-x fzf`
+fzf.el comes with some example commands to try out
+
+- `M-x switch-buffer`
+- `M-x fzf-find-file`
+- `M-x fzf-find-file-in-dir`
+- `M-x fzf-recentf`
+- `M-x fzf-grep`
+
+But the real action is writing your own. 
+
+fzf.el exposes three functions:
+
+- `fzf-with-entries (entries action &optional directory)`: run fzf, passing in an elisp list and running the function action with the user's selected results
+- `fzf-with-command (command action &optional directory)`: run a shell command and directly pass to fzf. An optimization on top of `fzf-with-entries` so that the output does not have to be stored in emacs before sending to fzf anyway.
+- `fzf-base (action &optional directory)`: run fzf with the user's default `FZF_DEFAULT_COMMAND`
+
+Using these functions, it's easy to define your own commands that use fzf:
+
+```lisp
+(defun fzf-example ()
+  (fzf-with-entries
+   (list "a" "b" "c")
+   'print))
+```
+
+Or more exiciting: [fzf-find-file](https://github.com/seenaburns/fzf.el/blob/master/fzf.el#L244)
+
+```lisp
+(defun fzf-find-file (&optional directory)
+  (interactive)
+  (let ((d (fzf/resolve-directory directory)))
+    (fzf
+    (lambda (x)
+        (let ((f (expand-file-name x d)))
+        (when (file-exists-p f)
+            (find-file f))))
+    d)))
+```
 
 # license
 


### PR DESCRIPTION
As brought up in bling/fzf.el/issues/24, fzf.el has set up fzf in emacs, but could be extended to work with many other things. This PR refactors fzf.el into 3 main functions:

- `fzf-with-entries (entries action &optional directory)`: run fzf, passing in an elisp list and running the function action with the user's selected results
- `fzf-with-command (command action &optional directory)`: run a shell command and directly pass to fzf. An optimization on top of `fzf-with-entries` so that the output does not have to be stored in emacs before sending to fzf anyway.
- `fzf-base (action &optional directory)`: run fzf with the user's default `FZF_DEFAULT_COMMAND`

Users then can define their own functions like

```lisp
(defun fzf-example ()
  (fzf-with-entries
   (list "a" "b" "c")
   'print))
```

But a handful of common functions like `fzf-files` and `fzf-grep` are predefined.

This PR does some other things as mentioned in the first commit (e.g. handle exit codes, cleaning up fzf), but in general I'm happy to work with you if you'd like it to be shaped differently.