### PR TITLE
Support Emacs 26 native line numbers

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -108,6 +108,7 @@
     (setq-local scroll-conservatively 0)
     (setq-local term-suppress-hard-newline t) ;for paths wider than the window
     (setq-local show-trailing-whitespace nil)
+    (setq-local display-line-numbers nil)
     (face-remap-add-relative 'mode-line '(:box nil))
 
     (term-char-mode)


### PR DESCRIPTION
Emacs 26 adds builtin line numbers - need to disable those too to
ensure the terminal width ends up correct.