### PR TITLE
fix byte-compiler, checkdoc, package-lint warnings

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -45,6 +45,7 @@
 ;;
 ;;; Code:
 
+(require 'term)
 (require 'subr-x)
 
 (defgroup fzf nil
@@ -111,7 +112,6 @@ the unicode character is to avoid any clash with real registers.")
   (advice-remove 'term-handle-exit #'fzf/after-term-handle-exit))
 
 (defun fzf/start (directory &optional cmd-stream)
-  (require 'term)
   (window-configuration-to-register fzf/window-register)
   (advice-add 'term-handle-exit :after #'fzf/after-term-handle-exit)
   (let* ((term-exec-hook nil)

--- a/fzf.el
+++ b/fzf.el
@@ -82,10 +82,9 @@
   :group 'fzf)
 
 (defconst fzf/window-register ?⬄
-  "A single character for fzf to save/restore the window
-configuration.  `window-configuration-to-register' expects a single
-character, so the unicode character is to avoid any clash with real
-registers.")
+  "A single character for fzf to save/restore the window configuration.
+`window-configuration-to-register' expects a single character, so
+the unicode character is to avoid any clash with real registers.")
 
 (defun fzf/grep-cmd (cmd args)
   (format (concat cmd " " args)
@@ -195,8 +194,8 @@ registers.")
 
 ;;;###autoload
 (defun fzf-git-grep ()
-  "Starts a fzf session based on git grep result.  The input comes
-   from the prompt or the selected region."
+  "Starts a fzf session based on git grep result.
+The input comes from the prompt or the selected region."
   (interactive)
   (fzf/start (locate-dominating-file default-directory ".git")
              (fzf/grep-cmd "git grep" fzf/git-grep-args)))

--- a/fzf.el
+++ b/fzf.el
@@ -27,7 +27,7 @@
 ;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
 ;; Floor, Boston, MA 02110-1301, USA.
 ;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Commentary:
 ;;
 ;; Install:
 ;;

--- a/fzf.el
+++ b/fzf.el
@@ -8,7 +8,7 @@
 ;; Created: 2015-09-18
 ;; Version: 0.0.2
 ;; Package-Requires: ((emacs "24.4"))
-;; Keywords: fzf fuzzy search
+;; Keywords: convenience fzf fuzzy search
 ;;
 ;; This file is not part of GNU Emacs.
 ;;

--- a/fzf.el
+++ b/fzf.el
@@ -52,7 +52,7 @@
   :group 'convenience)
 
 (defcustom fzf/window-height 15
-  "The window height of the fzf buffer"
+  "The window height of the fzf buffer."
   :type 'integer
   :group 'fzf)
 
@@ -67,7 +67,7 @@
   :group 'fzf)
 
 (defcustom fzf/git-grep-args "-i --line-number %s"
-  "Arguments to pass into git grep. %s is the search term placeholder"
+  "Arguments to pass into git grep. %s is the search term placeholder."
   :type 'string
   :group 'fzf)
 
@@ -196,7 +196,7 @@ registers.")
 ;;;###autoload
 (defun fzf-git-grep ()
   "Starts a fzf session based on git grep result. The input comes
-   from the prompt or the selected region"
+   from the prompt or the selected region."
   (interactive)
   (fzf/start (locate-dominating-file default-directory ".git")
              (fzf/grep-cmd "git grep" fzf/git-grep-args)))

--- a/fzf.el
+++ b/fzf.el
@@ -48,6 +48,9 @@
 (require 'term)
 (require 'subr-x)
 
+(declare-function projectile-project-root "projectile")
+(declare-function turn-off-evil-mode "evil")
+
 (defgroup fzf nil
   "Configuration options for fzf.el"
   :group 'convenience)

--- a/fzf.el
+++ b/fzf.el
@@ -1,4 +1,4 @@
-;;; fzf.el --- A front-end for fzf.
+;;; fzf.el --- A front-end for fzf
 ;;
 ;; Copyright (C) 2015 by Bailey Ling
 ;; Author: Bailey Ling

--- a/fzf.el
+++ b/fzf.el
@@ -155,7 +155,7 @@ the unicode character is to avoid any clash with real registers.")
 
 ;;;###autoload
 (defun fzf ()
-  "Starts a fzf session."
+  "Start a fzf session."
   (interactive)
   (if (fboundp #'projectile-project-root)
       (fzf/start (or (projectile-project-root) default-directory))
@@ -163,38 +163,38 @@ the unicode character is to avoid any clash with real registers.")
 
 ;;;###autoload
 (defun fzf-directory ()
-  "Starts a fzf session at the specified directory."
+  "Start a fzf session at the specified directory."
   (interactive)
   (fzf/start (ido-read-directory-name "Directory: " fzf/directory-start)))
 
 ;;;###autoload
 (defun fzf-git ()
-  "Starts a fzf session at the root of the current git."
+  "Start a fzf session at the root of the current git."
   (interactive)
   (fzf/vcs ".git"))
 
 ;;;###autoload
 (defun fzf-git-files ()
-  "Starts a fzf session only searching for git tracked files."
+  "Start a fzf session only searching for git tracked files."
   (interactive)
   (fzf/git-files))
 
 ;;;###autoload
 (defun fzf-hg ()
-  "Starts a fzf session at the root of the curreng hg."
+  "Start a fzf session at the root of the curreng hg."
   (interactive)
   (fzf/vcs ".hg"))
 
 ;;;###autoload
 (defun fzf-projectile ()
-  "Starts a fzf session at the root of the projectile project."
+  "Start a fzf session at the root of the projectile project."
   (interactive)
   (require 'projectile)
   (fzf/start (or (projectile-project-root) default-directory)))
 
 ;;;###autoload
 (defun fzf-git-grep ()
-  "Starts a fzf session based on git grep result.
+  "Start a fzf session based on git grep result.
 The input comes from the prompt or the selected region."
   (interactive)
   (fzf/start (locate-dominating-file default-directory ".git")

--- a/fzf.el
+++ b/fzf.el
@@ -67,12 +67,12 @@
   :group 'fzf)
 
 (defcustom fzf/git-grep-args "-i --line-number %s"
-  "Arguments to pass into git grep. %s is the search term placeholder."
+  "Arguments to pass into git grep.  %s is the search term placeholder."
   :type 'string
   :group 'fzf)
 
 (defcustom fzf/position-bottom t
-  "Set the position of the fzf window. Set to nil to position on top."
+  "Set the position of the fzf window.  Set to nil to position on top."
   :type 'bool
   :group 'fzf)
 
@@ -83,7 +83,7 @@
 
 (defconst fzf/window-register ?⬄
   "A single character for fzf to save/restore the window
-configuration. `window-configuration-to-register' expects a single
+configuration.  `window-configuration-to-register' expects a single
 character, so the unicode character is to avoid any clash with real
 registers.")
 
@@ -195,7 +195,7 @@ registers.")
 
 ;;;###autoload
 (defun fzf-git-grep ()
-  "Starts a fzf session based on git grep result. The input comes
+  "Starts a fzf session based on git grep result.  The input comes
    from the prompt or the selected region."
   (interactive)
   (fzf/start (locate-dominating-file default-directory ".git")


### PR DESCRIPTION
Hi!, I found this package, I fixes some warnings.
I file this PR as a first my contribution step!

### before
```
 fzf.el     0     info            You should have a section marked ";;; Commentary:" (emacs-lisp-checkdoc)
 fzf.el     1   1 error           Package should have a ;;; Commentary section. (emacs-lisp-package)
 fzf.el     1   1 warning         The package summary should not end with a period. (emacs-lisp-package)
 fzf.el    11   4 warning         You should include standard keywords: see the variable `finder-known-keywords'. (emacs-lisp-package)
 fzf.el    54   1 error           `fzf/window-height' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    55     info            First sentence should end with punctuation (emacs-lisp-checkdoc)
 fzf.el    59   1 error           `fzf/executable' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    64   1 error           `fzf/args' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    69   1 error           `fzf/git-grep-args' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    70     info            First sentence should end with punctuation (emacs-lisp-checkdoc)
 fzf.el    70     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 fzf.el    74   1 error           `fzf/position-bottom' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    75     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 fzf.el    79   1 error           `fzf/directory-start' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    84   1 error           `fzf/window-register' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    85     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 fzf.el    86     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 fzf.el    90   1 error           `fzf/grep-cmd' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    91     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el    97   1 error           `fzf/after-term-handle-exit' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    98     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   114   1 error           `fzf/start' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   115     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   137  44 warning         assignment to free variable ‘term-suppress-hard-newline’ (emacs-lisp)
 fzf.el   145   1 error           `fzf/vcs' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   146     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   151   1 error           `fzf/git-files' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   152     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   159     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   167     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   173     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   179     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   185     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   191     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   198     info            Second line should not have indentation (emacs-lisp-checkdoc)
 fzf.el   198     info            First line is not a complete sentence (emacs-lisp-checkdoc)
 fzf.el   198     info            Probably "Starts" should be imperative "Start" (emacs-lisp-checkdoc)
 fzf.el   198     info            There should be two spaces after a period (emacs-lisp-checkdoc)
 fzf.el   206   1 warning         the following functions are not known to be defined: turn-off-evil-mode, term-char-mode, projectile-project-root (emacs-lisp)
```

### after
```
 fzf.el    58   1 error           `fzf/window-height' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    63   1 error           `fzf/executable' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    68   1 error           `fzf/args' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    73   1 error           `fzf/git-grep-args' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    78   1 error           `fzf/position-bottom' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    83   1 error           `fzf/directory-start' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    88   1 error           `fzf/window-register' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    93   1 error           `fzf/grep-cmd' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el    94     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   100   1 error           `fzf/after-term-handle-exit' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   101     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   117   1 error           `fzf/start' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   118     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   139  44 warning         ‘term-suppress-hard-newline’ is an obsolete variable (as of 27.1). (emacs-lisp)
 fzf.el   147   1 error           `fzf/vcs' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   148     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
 fzf.el   153   1 error           `fzf/git-files' contains a non-standard separator `/', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
 fzf.el   154     info            All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
```

### Note
`term-suppress-hard-newline` is marked as a obsolete variable from Emacs-27.`