### PR TITLE
Fix #64: fzf show only files in a directory of fzf executable

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -286,7 +286,7 @@ to start in."
   (cond
    (directory directory)
    ((fboundp #'projectile-project-root) (condition-case err (projectile-project-root) (error default-directory)))
-   (t "")
+   (t default-directory)
   )
 )
 


### PR DESCRIPTION
This pull request is to fix issue #64. Thanks. 