### PR TITLE
Prevent error when fzf-switch-buffer is called

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -143,7 +143,10 @@ configuration.")
         (let* ((text (buffer-substring-no-properties (point-min) (point-max)))
                 (lines (split-string text "\n" t "\s*>\s+"))
                 (target (car (last (butlast lines 1))))
-                (target-full (concat (file-name-as-directory directory) target))
+                (target-full (concat
+                              (if directory
+                                  (file-name-as-directory directory))
+                              target))
             )
             ; Kill fzf and restore windows
             ; Killing has to happen before applying the action so functions like swaping the buffer


### PR DESCRIPTION
When `fzf-switch-buffer` is called, directory will be nil, causing Emacs to report error:

```
  error in process sentinel: concat: Wrong type argument: stringp, nil
```

This commit checks if directory is nil and ignore file-name-as-directory call in that case.