### PR TITLE
Make `grep` configurable and add `fzf/grep-dwim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ An Emacs front-end for [fzf][1].
 
 # installation
 
-fzf.el can be installed through [MELPA][2].
+`fzf.el` is available on [MELPA][2].
+
+Below is an illustrative `use-package` configuration of `fzf.el` showing all
+available customizations and their default values.
+
+> **Note**: This package does not set default keybindings.
+
+```lisp
+(use-package fzf
+  :bind
+    ;; Don't forget to set keybinds!
+  :config
+  (setq fzf/args "-x --color bw --print-query --margin=1,0 --no-hscroll"
+        fzf/executable "fzf"
+        fzf/git-grep-args "-i --line-number %s"
+        ;; command used for `fzf-grep-*` functions
+        ;; example usage for ripgrep:
+        ;; fzf/grep-command "rg --no-heading -nH"
+        fzf/grep-command "grep -nrH"
+        ;; If nil, the fzf buffer will appear at the top of the window
+        fzf/position-bottom t
+        fzf/window-height 15))
+```
 
 # usage
 
@@ -24,6 +46,7 @@ fzf.el comes with some example commands to try out
 - `M-x fzf-git-grep`
 - `M-x fzf-recentf`
 - `M-x fzf-grep`
+- `M-x fzf-grep-dwim`
 
 But the real action is writing your own.
 


### PR DESCRIPTION
# Changes

- Add customizable option `fzf/grep-command` for the default `grep` command. Default is `grep -nrH` (same as before)
- Slight refactor of `fzf-grep`
  - Use `fzf/start` instead of `fzf-with-command` now that `fzf/start` supports commands
  - Use `fzf/grep-command` to allow user customization
  - Use `fzf/resolve-directory` instead of `default-directory`. This will function the same as it is currently except if in a `projectile` project, in which case the root of the project is used. 
- Add `fzf-grep-dwim` to lookup `thing-at-point`

I also added a section to the README showing customization options. 