### PR TITLE
Add support for custom narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ fzf.el comes with some example commands to try out
 - `M-x fzf-git-grep`
 - `M-x fzf-recentf`
 - `M-x fzf-grep`
+- `M-x fzf-grep-in-dir`
+- `M-x fzf-grep-with-narrowing`
+- `M-x fzf-grep-in-dir-with-narrowing`
 - `M-x fzf-grep-dwim`
 
 But the real action is writing your own.

--- a/README.md
+++ b/README.md
@@ -32,31 +32,47 @@ available customizations and their default values.
 
 # usage
 
-fzf.el comes with some example commands to try out
+`fzf.el` comes with a number of useful commands:
 
+### Using `FZF_DEFAULT_COMMAND`:
 - `M-x fzf`
 - `M-x fzf-directory`
-- `M-x fzf-switch-buffer`
+
+### Searching for files:
 - `M-x fzf-find-file`
 - `M-x fzf-find-file-in-dir`
+- `M-x fzf-recentf`
+
+### Project-aware search:
 - `M-x fzf-git`
 - `M-x fzf-git-files`
+- `M-x fzf-git-grep`
 - `M-x fzf-hg`
 - `M-x fzf-projectile`
-- `M-x fzf-git-grep`
-- `M-x fzf-recentf`
+
+### Grep:
+> **Note**: `fzf-grep-*-with-narrowing` functions launch an interactive `fzf/grep-command` instead of using fuzzy filtering. [See the fzf advanced documentation for more details](https://github.com/junegunn/fzf/blob/master/ADVANCED.md).
 - `M-x fzf-grep`
+- `M-x fzf-grep-dwim`
 - `M-x fzf-grep-in-dir`
 - `M-x fzf-grep-with-narrowing`
+- `M-x fzf-grep-dwim-with-narrowing`
 - `M-x fzf-grep-in-dir-with-narrowing`
-- `M-x fzf-grep-dwim`
 
-But the real action is writing your own.
+### Using input from Emacs:
+- `M-x fzf-switch-buffer`
 
-fzf.el exposes three functions:
+## define custom functions
 
-- `fzf-with-entries (entries action &optional directory)`: run fzf, passing in an elisp list and running the function action with the user's selected results
-- `fzf-with-command (command action &optional directory)`: run a shell command and directly pass to fzf. An optimization on top of `fzf-with-entries` so that the output does not have to be stored in emacs before sending to fzf anyway.
+`fzf.el` exposes functions to let you interface with `fzf` however you'd like:
+
+- `fzf-with-command (command action &optional directory as-filter initq)`: Run `fzf` on the output of a shell command.
+    - `command`: The shell command whose output is passed to `fzf`.
+    - `action`: A function that handles the result of `fzf` (e.g. open a file, switch to a buffer, etc.). This package ships with two default actions that can handle opening a file and opening a file at a specific line.
+    - `directory`: Directory to execute `fzf` in.
+    - `as-filter`: If non-nil, use `command` as the filter instead of `fzf`'s fuzzy filtering. See `fzf-grep-*-with-narrowing` functions for example usages.
+    - `initq`: If `as-filter` is non-nil, `initq` will be used as the value for the `--query` option. If `as-filter` is nil, this does nothing.
+- `fzf-with-entries (entries action &optional directory)`: run fzf, passing in an elisp list and running the function action with the user's selected results.
 
 Using these functions, it's easy to define your own commands that use fzf:
 

--- a/fzf.el
+++ b/fzf.el
@@ -180,7 +180,7 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
          (window-height (if fzf/position-bottom (- min-height) min-height))
          (sh-cmd (concat (when cmd (concat cmd " | ")) fzf/executable " " fzf/args)))
     (with-current-buffer buf
-      (setq default-directory (if directory directory "")))
+      (setq default-directory (or directory "")))
     (split-window-vertically window-height)
     (when fzf/position-bottom (other-window 1))
     (make-term fzf/executable "sh" nil "-c" sh-cmd)
@@ -189,19 +189,19 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     (linum-mode 0)
     (visual-line-mode 0)
 
-    (setq fzf-hook (fzf/after-term-handle-exit directory action))
-
     ;; disable various settings known to cause artifacts, see #1 for more details
-    (setq-local scroll-margin 0)
-    (setq-local scroll-conservatively 0)
-    (setq-local term-suppress-hard-newline t) ;for paths wider than the window
-    (setq-local show-trailing-whitespace nil)
-    (setq-local display-line-numbers nil)
-    (setq-local truncate-lines t)
+    (setq-local scroll-margin 0
+                scroll-conservatively 0
+                term-suppress-hard-newline t
+                show-trailing-whitespace nil
+                display-line-numbers nil
+                truncate-lines t)
     (face-remap-add-relative 'mode-line '(:box nil))
 
     (term-char-mode)
-    (setq mode-line-format (format "   FZF  %s" directory))))
+    (setq fzf-hook (fzf/after-term-handle-exit directory action)
+          mode-line-format (format "   FZF  %s" (or directory "")))))
+
 
 (defun fzf/action-find-file (target)
   (when (file-exists-p target)

--- a/fzf.el
+++ b/fzf.el
@@ -396,6 +396,16 @@ If `thing-at-point` is not a symbol, read input interactively."
     (fzf-grep)))
 
 ;;;###autoload
+(defun fzf-grep-dwim-with-narrowing ()
+  "Call `fzf-grep` on `symbol-at-point`, with grep as the narrowing filter.
+
+If `thing-at-point` is not a symbol, read input interactively."
+  (interactive)
+  (if (symbol-at-point)
+      (fzf-grep (thing-at-point 'symbol) nil t)
+    (fzf-grep nil nil t)))
+
+;;;###autoload
 (defun fzf-git ()
   "Starts an fzf session at the root of the current git project."
   (interactive)

--- a/fzf.el
+++ b/fzf.el
@@ -226,7 +226,7 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
   (fzf/start (fzf/resolve-directory) #'fzf/action-find-file)
 )
 
-(defun fzf-with-command (command action &optional directory as-filter)
+(defun fzf-with-command (command action &optional directory as-filter initq)
   "Run `fzf` on the output of COMMAND.
 
 If COMMAND is nil, use the default `FZF_DEFAULT_COMMAND`.
@@ -239,7 +239,7 @@ selected result from `fzf`.
 DIRECTORY is the directory to start in.
 
 If AS-FILTER is non-nil, use command as the narrowing filter instead of fzf,
-as explained here:
+with INITQ as the initial query, as explained here:
 https://github.com/junegunn/fzf/blob/master/ADVANCED.md#using-fzf-as-interative-ripgrep-launcher
 E.g. If COMMAND is grep, use grep as a narrowing filter to interactively
 reduce the search space, instead of using fzf to filter (but not narrow)."
@@ -250,6 +250,7 @@ reduce the search space, instead of using fzf to filter (but not narrow)."
            (args (if as-filter
                      (concat fzf/args
                              " --disabled"
+                             " --query " initq
                              " --bind \"change:reload:sleep 0.1; "
                              fzf/grep-command
                              " {q} || true\"")
@@ -359,7 +360,7 @@ If AS-FILTER is non-nil, use grep as the narrowing filter instead of fzf."
          (pattern (or search
                       (read-from-minibuffer (concat fzf/grep-command ": "))))
          (cmd (concat fzf/grep-command " " pattern)))
-    (fzf-with-command cmd action dir as-filter)))
+    (fzf-with-command cmd action dir as-filter pattern)))
 
 ;;;###autoload
 (defun fzf-grep-in-dir (&optional directory as-filter)

--- a/fzf.el
+++ b/fzf.el
@@ -166,7 +166,7 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     ;; This gets added back in `fzf/start`
     (advice-remove 'term-handle-exit (fzf/after-term-handle-exit directory action))))
 
-(defun fzf/start (directory action &optional cmd)
+(defun fzf/start (directory action &optional custom-args)
   (require 'term)
 
   ; Clean up existing fzf
@@ -178,7 +178,8 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
          (buf (get-buffer-create fzf/buffer-name))
          (min-height (min fzf/window-height (/ (window-height) 2)))
          (window-height (if fzf/position-bottom (- min-height) min-height))
-         (sh-cmd (concat (when cmd (concat cmd " | ")) fzf/executable " " fzf/args)))
+         (args (or custom-args fzf/args))
+         (sh-cmd (concat fzf/executable " " args)))
     (with-current-buffer buf
       (setq default-directory (or directory "")))
     (split-window-vertically window-height)
@@ -225,17 +226,36 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
   (fzf/start (fzf/resolve-directory) #'fzf/action-find-file)
 )
 
-(defun fzf-with-command (command action &optional directory)
+(defun fzf-with-command (command action &optional directory as-filter)
   "Run `fzf` on the output of COMMAND.
 
-If COMMAND is nil, use `FZF_DEFAULT_COMMAND`.
+If COMMAND is nil, use the default `FZF_DEFAULT_COMMAND`.
+Otherwise set `FZF_DEFAULT_COMMAND` to COMMAND.
+COMMAND can be a sequence of piped commands to input to FZF.
+
 ACTION is a function that takes a single argument, which is the
-selected result from `fzf`.  DIRECTORY is the directory to start in."
+selected result from `fzf`.
+
+DIRECTORY is the directory to start in.
+
+If AS-FILTER is non-nil, use command as the narrowing filter instead of fzf,
+as explained here:
+https://github.com/junegunn/fzf/blob/master/ADVANCED.md#using-fzf-as-interative-ripgrep-launcher
+E.g. If COMMAND is grep, use grep as a narrowing filter to interactively
+reduce the search space, instead of using fzf to filter (but not narrow)."
   (interactive)
   (if command
-      (fzf/start directory action command)
-    (fzf/start directory action))
-)
+      (let
+          ((process-environment (cons (concat "FZF_DEFAULT_COMMAND=" command "") process-environment))
+           (args (if as-filter
+                     (concat fzf/args
+                             " --disabled"
+                             " --bind \"change:reload:sleep 0.1; "
+                             fzf/grep-command
+                             " {q} || true\"")
+                   fzf/args)))
+        (fzf/start directory action args))
+    (fzf/start directory action)))
 
 ;;;###autoload
 (defun fzf-with-entries (entries action &optional directory)
@@ -327,15 +347,42 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
 )
 
 ;;;###autoload
-(defun fzf-grep (search &optional directory)
+(defun fzf-grep (&optional search directory as-filter)
   "Call `fzf/grep-command` on SEARCH.
 
-Grep in `fzf/resolve-directory` using DIRECTORY if provided."
-  (interactive "sGrep: ")
+If SEARCH is nil, read input interactively.
+Grep in `fzf/resolve-directory` using DIRECTORY if provided.
+If AS-FILTER is non-nil, use grep as the narrowing filter instead of fzf."
+  (interactive)
   (let* ((dir (fzf/resolve-directory directory))
          (action #'fzf/action-find-file-with-line)
-         (cmd (concat fzf/grep-command " " search)))
-    (fzf/start dir action cmd)))
+         (pattern (or search
+                      (read-from-minibuffer (concat fzf/grep-command ": "))))
+         (cmd (concat fzf/grep-command " " pattern)))
+    (fzf-with-command cmd action dir as-filter)))
+
+;;;###autoload
+(defun fzf-grep-in-dir (&optional directory as-filter)
+  "Call `fzf-grep` in DIRECTORY.
+
+If DIRECTORY is nil, read input interactively.
+If AS-FILTER is non-nil, use grep as the narrowing filter instead of fzf."
+  (interactive)
+  (let ((dir (or directory
+                 (read-directory-name "Directory: " fzf/directory-start))))
+    (fzf-grep nil dir as-filter)))
+
+;;;###autoload
+(defun fzf-grep-with-narrowing ()
+  "Call `fzf-grep` with grep as the narrowing filter."
+  (interactive)
+  (fzf-grep nil nil t))
+
+;;;###autoload
+(defun fzf-grep-in-dir-with-narrowing ()
+  "Call `fzf-grep-in-dir` with grep as the narrowing filter."
+  (interactive)
+  (fzf-grep-in-dir nil t))
 
 ;;;###autoload
 (defun fzf-grep-dwim ()
@@ -345,7 +392,7 @@ If `thing-at-point` is not a symbol, read input interactively."
   (interactive)
   (if (symbol-at-point)
       (fzf-grep (thing-at-point 'symbol))
-    (call-interactively #'fzf-grep)))
+    (fzf-grep)))
 
 ;;;###autoload
 (defun fzf-git ()


### PR DESCRIPTION
> **Note**: This PR is heavily informed by the [`fzf` advanced use documentation](https://github.com/junegunn/fzf/blob/master/ADVANCED.md). For complete context, do read the documentation. Although the documentation mentions `ripgrep` specifically, the ideas expand to any kind of custom narrowing (although the performance gain may not)


# Changes

*__in descending priority order__*

- Reintroduce `FZF_DEFAULT_COMMAND` usage to support custom narrowing 
    - From the `fzf` documentation:
        > Instead of starting fzf in `rg ... | fzf` form, we start fzf without an explicit input, but with a custom FZF_DEFAULT_COMMAND variable. This way fzf can kill the initial Ripgrep process it starts with the initial query. Otherwise, the initial Ripgrep process will keep consuming system resources even after reload is triggered.
- Add `fzf-grep-with-narrowing`, `fzf-grep-in-dir-with-narrowing`, and `fzf-grep-dwim-with-narrowing`
    - These functions use the `fzf/grep-command` as the narrowing function to incrementally expand/contract the search space. This adds the functionality requested in #72
    - From the `fzf` documentation:
        > fzf will restart Ripgrep every time the user updates the query string on fzf. Searching and filtering is completely done by Ripgrep, and fzf merely provides the interactive interface. So we lose the "fuzziness", but the performance will be better on larger projects, and it will free up memory as you narrow down the results.
- `fzf-with-command` now takes an optional "bool" arg `as-filter`. When non-nil, the `command` arg will also be used as the narrowing filter instead of the typical fuzzy filtering. 
- Remove the `cmd` arg from `fzf/start` in favor of the previous strategy of setting `FZF_DEFAULT_COMMAND`. Update `fzf/start` to take an optional `custom-args` param. In order to use a custom narrowing function, we need to disable `fzf`'s fuzzy filtering and provide it with additional options to define the narrowing function. 
- Update `fzf-grep` to read the search term interactively using `read-from-minibuffer` instead of using `interactive` with a required argument. This makes it easier to re-use it in other grep functions that may want to have interactive input. 
- Only show the directory in the modeline if provided. 
    - This prevents showing `nil` when using `fzf-with-entries` (e.g. `fzf-switch-buffer`)
- Grouped `setq`s in `fzf/start`

# Breaking Changes

None. All function signatures have been updated to add tail optional params, or in the case of `fzf-grep`, updated to maintain parity with the previous implementation.

# Upcoming

I tested all the functions by hand to check for regressions, but this package is growing beyond that. I am going to look into adding unit tests next.