### PR TITLE
use read-directory-name for find-file-in-dir

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -327,10 +327,11 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
 )
 
 ;;;###autoload
-(defun fzf-find-file-in-dir (directory)
-  (interactive "sDirectory: ")
-  (fzf-find-file directory)
-)
+(defun fzf-find-file-in-dir (&optional directory)
+  (interactive)
+  (let ((dir (or directory
+                 (read-directory-name "Directory: " fzf/directory-start))))
+    (fzf-find-file dir)))
 
 ;;;###autoload
 (defun fzf-git-grep ()


### PR DESCRIPTION
Small backwards-compatible change for `find-file-in-dir` that uses `read-directory-name` instead of a required interactive arg to get mini buffer completion on directory names (i.e. type ".co" TAB complete to ".config").