### PR TITLE
Fix fzf not working in Emacs 29 build 2022-10-20

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -187,7 +187,8 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     (make-term fzf/executable "sh" nil "-c" sh-cmd)
     (switch-to-buffer buf)
     (and (fboundp #'turn-off-evil-mode) (turn-off-evil-mode))
-    (linum-mode 0)
+    (when (not (version<= "28.0.50" emacs-version))
+      (linum-mode 0))
     (visual-line-mode 0)
 
     ;; disable various settings known to cause artifacts, see #1 for more details


### PR DESCRIPTION
(linum-mode 0) was causing fzf to not work in the Emacs 29 build of 2022-10-20. After adding a conditional statement for running this funtion that checks the version of Emacs, it was working again.