### PR TITLE
More byte-compiler warning fixes & error handling improvements

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -172,7 +172,6 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
 (defun fzf/start (directory action &optional custom-args)
   (require 'term)
 
-
   ;; Clean up existing fzf
   (fzf-close)
 
@@ -204,7 +203,7 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     (setq-local truncate-lines t)
     (face-remap-add-relative 'mode-line '(:box nil))
 
-    (term-char-mode)
+    (and (fboundp 'term-char-mode) (term-char-mode))
     (setq fzf-hook (fzf/after-term-handle-exit directory action)
           mode-line-format (format "   FZF  %s" (or directory "")))))
 

--- a/fzf.el
+++ b/fzf.el
@@ -336,10 +336,12 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
 )
 
 ;;;###autoload
-(defun fzf-find-file-in-dir (directory)
-  (interactive "sDirectory: ")
-  (fzf-find-file directory)
-)
+(defun fzf-find-file-in-dir (&optional directory)
+  (interactive)
+  (let ((dir (or directory
+                 (read-directory-name "Directory: " fzf/directory-start))))
+    (fzf-find-file dir)))
+
 
 ;;;###autoload
 (defun fzf-git-grep ()

--- a/fzf.el
+++ b/fzf.el
@@ -355,7 +355,7 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
 (defun fzf-recentf ()
   "Start a fzf session with the list of recently opened files."
   (interactive)
-  (if (bound-and-true-p 'recentf-list)
+  (if (bound-and-true-p recentf-list)
       (fzf-with-entries recentf-list #'fzf/action-find-file)
     (user-error "No recently opened files.%s"
                 (if (boundp 'recentf-list)

--- a/fzf.el
+++ b/fzf.el
@@ -122,7 +122,7 @@ configuration.")
 
 ; Awkward internal, global variable to save the reference to the 'term-handle-exit hook so it can be
 ; deleted
-(setq fzf-hook nil)
+(defvar fzf-hook nil)
 
 (defun fzf-close()
   (interactive)

--- a/fzf.el
+++ b/fzf.el
@@ -353,9 +353,15 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
 
 ;;;###autoload
 (defun fzf-recentf ()
+  "Start a fzf session with the list of recently opened files."
   (interactive)
-  (fzf-with-entries recentf-list #'fzf/action-find-file)
-)
+  (if (bound-and-true-p 'recentf-list)
+      (fzf-with-entries recentf-list #'fzf/action-find-file)
+    (user-error "No recently opened files.%s"
+                (if (boundp 'recentf-list)
+                    ""
+                  " recentf-mode is not active!"))))
+
 
 ;;;###autoload
 (defun fzf-grep (&optional search directory as-filter)

--- a/fzf.el
+++ b/fzf.el
@@ -191,7 +191,8 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     (make-term fzf/executable "sh" nil "-c" sh-cmd)
     (switch-to-buffer buf)
     (and (fboundp 'turn-off-evil-mode) (turn-off-evil-mode))
-    (linum-mode 0)
+    (when (not (version<= "28.0.50" emacs-version))
+      (linum-mode 0))
     (visual-line-mode 0)
 
     ;; disable various settings known to cause artifacts, see #1 for more details

--- a/fzf.el
+++ b/fzf.el
@@ -296,10 +296,13 @@ selected result from `fzf`. DIRECTORY is the directory to start in"
   ;    (fzf/resolve-directory directory)))
   (cond
    (directory directory)
-   ((fboundp #'projectile-project-root) (condition-case err (projectile-project-root) (error default-directory)))
-   (t default-directory)
-  )
-)
+   ((fboundp #'projectile-project-root)
+    (condition-case err
+        (projectile-project-root)
+      (error "Error: default-directory: %s; %s"
+             default-directory
+             (error-message-string err))))
+   (t default-directory)))
 
 
 ;;;###autoload

--- a/fzf.el
+++ b/fzf.el
@@ -191,12 +191,12 @@ If DIRECTORY is provided, it is prepended to the result of fzf."
     (visual-line-mode 0)
 
     ;; disable various settings known to cause artifacts, see #1 for more details
-    (setq-local scroll-margin 0
-                scroll-conservatively 0
-                term-suppress-hard-newline t
-                show-trailing-whitespace nil
-                display-line-numbers nil
-                truncate-lines t)
+    (setq-local scroll-margin 0)
+    (setq-local scroll-conservatively 0)
+    (setq-local term-suppress-hard-newline t)
+    (setq-local show-trailing-whitespace nil)
+    (setq-local display-line-numbers nil)
+    (setq-local truncate-lines t)
     (face-remap-add-relative 'mode-line '(:box nil))
 
     (term-char-mode)

--- a/fzf.el
+++ b/fzf.el
@@ -89,7 +89,7 @@ See `fzf/action-find-file-with-line` for details on how output is parsed."
 
 (defcustom fzf/position-bottom t
   "Set the position of the fzf window. Set to nil to position on top."
-  :type 'bool
+  :type 'boolean
   :group 'fzf)
 
 (defconst fzf/buffer-name "*fzf*"


### PR DESCRIPTION
The first part  and some other changes of the set were already merged in bling master.  The remaining include more warning fixes and error handling logic improvements:
- the `fboundp` calls need quoted symbols as arguments, not pound quoted.
- there might be **no** recent files (or the recentf.el is not loaded): account for that and report a user error.
- even if `require` is used to load a file, its functions and variables must be declared otherwise the byte-compiler  complains when the require is inside a form.  
  - For function: add a `fboundp` check conditional.
  - For variable: add a defvar form that does not set the initial value.