### PR TITLE
Issue #84 Fix.  Also fixes issue #82.

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -36,8 +36,6 @@
 ;; Usage:
 ;;
 ;; M-x fzf
-;; M-x fzf-with-command
-;; M-x fzf-with-entries
 ;; M-x fzf-directory
 ;; M-x fzf-switch-buffer
 ;; M-x fzf-find-file
@@ -51,9 +49,19 @@
 ;; M-x fzf-grep
 ;; M-x fzf-grep-dwim
 ;;
+;; Naming conventions:
+;;
+;; - All symbols have a name that starts with 'fzf'
+;; - All user options: `fzf/XXXX'
+;; - All interactive and publicly available functions and variables: `fzf', `fzf-XXXX'
+;; - All internal functions and variables: `fzf--XXXX'
+
 ;;; Code:
 
 (require 'subr-x)
+
+;; ---------------------------------------------------------------------------
+;; Customization support
 
 (defgroup fzf nil
   "Configuration options for fzf.el"
@@ -78,7 +86,7 @@
   "Command used for `fzf-grep-*` functions.
 
 Output of this command must be in the form <FILE>:<LINE NUMBER>:<LINE>.
-See `fzf/action-find-file-with-line` for details on how output is parsed."
+See `fzf--action-find-file-with-line` for details on how output is parsed."
   :type 'string
   :group 'fzf)
 
@@ -104,31 +112,35 @@ configuration.")
   :type 'string
   :group 'fzf)
 
-(defun fzf/grep-cmd (cmd args)
+;; ---------------------------------------------------------------------------
+
+;; Internal helper function
+(defun fzf--grep-cmd (cmd args)
   (format (concat cmd " " args)
           (shell-quote-argument
            (if (region-active-p)
                (buffer-substring-no-properties (region-beginning) (region-end))
              (read-from-minibuffer (concat cmd ": "))))))
 
-(defun fzf/exit-code-from-event (msg)
+;; Internal helper function
+(defun fzf--exit-code-from-event (msg)
   "Return 0 if msg is finished, 1 if can parse, \"unknown\" if unknown"
   (cond
    ((string-match-p "finished" msg) "0")
    ((string-match-p "exited abnormally" msg) (car (last (split-string msg))))
-   (t "unknown")
-  )
-)
+   (t "unknown")))
 
-; Awkward internal, global variable to save the reference to the 'term-handle-exit hook so it can be
-; deleted
-(defvar fzf-hook nil)
+;; Awkward internal, global variable to save the reference to the
+;; 'term-handle-exit hook so it can be deleted
+(defvar fzf--hook nil
+  "Remembers 'term-handle-exit hook to allow its later deletion.")
 
-(defun fzf-close()
+;; Internal helper function
+(defun fzf--close()
   "Cleanup hooks and process."
   ; Remove hook first so it doesn't trigger when process is killed
-  (when fzf-hook (advice-remove 'term-handle-exit fzf-hook))
-  (setq fzf-hook nil)
+  (when fzf--hook (advice-remove 'term-handle-exit fzf--hook))
+  (setq fzf--hook nil)
 
   ; Kill process so user isn't prompted
   (when (get-process fzf/executable)
@@ -139,7 +151,56 @@ configuration.")
     (kill-buffer fzf/buffer-name)
     (jump-to-register fzf/window-register)))
 
-(defun fzf/after-term-handle-exit (directory action)
+;; Internal helper function
+(defun fzf--pass-through (target _text _msg _process-name)
+  "Pass-through validator: returns TARGET.
+Ignores the other 3 arguments: _TEXT _MSG _PROCESS-NAME."
+  target)
+
+;; Internal helper function
+(defun fzf--validate-filename (target text msg process-name)
+  "Validate and return validated TARGET as valid file name.
+
+Extra arguments used to provide contextual information in case of
+error:
+- TEXT:         string: complete text returned by FZF.
+- MSG:          string: FZF termination message.
+- PROCESS_NAME: string: name of used executable (fzf/executable)."
+  (let ((orig-target target))
+    ;; Sometimes the string returned by fzf has extraneous characters at the
+    ;; end of the real/correct file name. Attempt to extract the correct
+    ;; file name by stripping 1 character at a time from the end.
+    (unless (file-exists-p target)
+      (while (and  (not (string= "" target))
+                   (not (file-exists-p target)))
+        (setq target (substring target 0 -1))))
+    ;; report any remaining error by message instead of exception since
+    ;; we're in a handler we can't interrupt and provides a better trace.
+    (when (or (string= "" target)
+              (not (file-exists-p target)))
+      (message "TERMINATING: process:[%s], msg:[%s]" process-name msg )
+      (message "FZF PROBLEM: non existing file identified [%s]" orig-target)
+      (message "FZF returned text: [%s]" text))
+    ;; return potentially adjusted file name
+    target))
+
+(defvar fzf-target-validator  (function fzf--validate-filename)
+  "FZF found target validator & filter function.
+
+- Takes 4 arguments: (target text msg process-name)
+- Returns target (a string).  If that target is valid,
+  the function must return it unchanged.  If it was not valid
+  and needed to be modified the function must return the modified
+  target string.
+
+The default is the file validator `fzf--validate-filename' used
+as an example. When requiring something different let-bind the
+variable to your own validator in your function that will
+eventually execute the `fzf--start' and the
+`fzf--after-term-handle-exit' which uses the validator.")
+
+;; Internal helper function
+(defun fzf--after-term-handle-exit (directory action target-validator)
   "Create and return lambda that handles the result of fzf.
 
 The lambda must conform to `term-handle-exit':  i.e. accept 2 arguments:
@@ -148,29 +209,15 @@ The lambda must conform to `term-handle-exit':  i.e. accept 2 arguments:
 The lambda will call ACTION on the result of fzf if fzf exited successfully.
 DIRECTORY, if non-nil, is prepended to the result of fzf."
   (lambda (process-name msg)
-    (let* ((exit-code (fzf/exit-code-from-event msg))
+    (let* ((exit-code (fzf--exit-code-from-event msg))
            (text (buffer-substring-no-properties (point-min) (point-max)))
            (lines (split-string text "\n" t "\s*>\s+"))
            (target (string-trim
                     (concat
                      (when directory
                        (file-name-as-directory directory))
-                     (car (last (butlast lines))))))
-           (orig-target target))
-      ;; Sometimes the string returned by fzf has extraneous characters at the
-      ;; end of the real/correct file name. Attempt to extract the correct
-      ;; file name by stripping 1 character at a time from the end.
-      (unless (file-exists-p target)
-        (while (and  (not (string= "" target))
-                     (not (file-exists-p target)))
-          (setq target (substring target 0 -1))))
-      ;; report any remaining error by message instead of exception since
-      ;; we're in a handler we can't interrupt and provides a better trace.
-      (when (or (string= "" target)
-                (not (file-exists-p target)))
-        (message "TERMINATING: process:[%s], msg:[%s]" process-name msg )
-        (message "FZF PROBLEM: non existing file identified [%s]" orig-target)
-        (message "FZF returned text: [%s]" text))
+                     (car (last (butlast lines)))))))
+      (setq target (funcall target-validator target text msg process-name))
       ;; Kill the fzf buffer and restore the previous window configuration.
       (kill-buffer fzf/buffer-name)
       (jump-to-register fzf/window-register)
@@ -178,21 +225,27 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
       ;; Only do something with the result if fzf was successful.
       (when (string= "0" exit-code) (funcall action target)))
     ;; Remove this advice so as to not interfere with other usages of `term`.
-    ;; This gets added back in `fzf/start`
+    ;; This gets added back in `fzf--start`
     (advice-remove 'term-handle-exit
-                   (fzf/after-term-handle-exit directory action))))
+                   (fzf--after-term-handle-exit directory action target-validator))))
 
 (defvar term-exec-hook)               ; prevent byte-compiler warning
 (defvar term-suppress-hard-newline)   ; prevent byte-compiler warning
 
-(defun fzf/start (directory action &optional custom-args)
+;; Internal helper function
+(defun fzf--start (directory action &optional custom-args)
+  "Launch `fzf/executable' in terminal, extract and act on selected item."
   (require 'term)
 
-  ;; Clean up existing fzf
-  (fzf-close)
+  ;; Clean up existing fzf, allowing multiple action types.
+  (fzf--close)
 
+  ;; launch process in an inferior terminal mapped in current window
   (window-configuration-to-register fzf/window-register)
-  (advice-add 'term-handle-exit :after (fzf/after-term-handle-exit directory action))
+  (advice-add 'term-handle-exit
+              :after (fzf--after-term-handle-exit directory
+                                                  action
+                                                  fzf-target-validator))
   (let* ((term-exec-hook nil)
          (buf (get-buffer-create fzf/buffer-name))
          (min-height (min fzf/window-height (/ (window-height) 2)))
@@ -205,11 +258,18 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
     (when fzf/position-bottom (other-window 1))
     (make-term fzf/executable "sh" nil "-c" sh-cmd)
     (switch-to-buffer buf)
-    (and (fboundp 'turn-off-evil-mode) (turn-off-evil-mode))
-    (when (not (version<= "28.0.50" emacs-version))
-      (linum-mode 0))
-    (visual-line-mode 0)
 
+    ;; Disable minor modes that interfere with rendering while fzf is running
+    ;; TODO: provide ability to modify the set of actions in the user-option
+    ;;       to allow compatibility with more minor modes instead of using
+    ;;       this hard coded set.
+    (and (fboundp 'turn-off-evil-mode) (turn-off-evil-mode))
+    (when (bound-and-true-p linum-mode)
+      (linum-mode 0))
+    (when (bound-and-true-p visual-line-mode)
+      (visual-line-mode 0))
+    (when (bound-and-true-p display-line-numbers-mode)
+      (display-line-numbers-mode 0))
     ;; disable various settings known to cause artifacts, see #1 for more details
     (setq-local scroll-margin 0)
     (setq-local scroll-conservatively 0)
@@ -220,25 +280,24 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
     (face-remap-add-relative 'mode-line '(:box nil))
 
     (and (fboundp 'term-char-mode) (term-char-mode))
-    (setq fzf-hook (fzf/after-term-handle-exit directory action)
+    ;; Remember the used terminal exit handler to allow its later removal.
+    (setq fzf--hook (fzf--after-term-handle-exit directory action fzf-target-validator)
           mode-line-format (format "   FZF  %s" (or directory "")))))
 
-
-(defun fzf/action-find-file (target)
+;; Internal helper function
+(defun fzf--action-find-file (target)
   (when (file-exists-p target)
-    (find-file target))
-)
+    (find-file target)))
 
-(defun fzf/action-find-file-with-line (target)
-  (fzf/action-find-file target)
+;; Internal helper function
+(defun fzf--action-find-file-with-line (target)
+  (fzf--action-find-file target)
   (let* ((parts (split-string target ":"))
          (f (expand-file-name (nth 0 parts))))
     (when (file-exists-p f)
       (find-file f)
       (goto-char (point-min))
-      (forward-line (string-to-number (nth 1 parts))))
-  )
-)
+      (forward-line (string-to-number (nth 1 parts))))))
 
 ;;;###autoload
 (defun fzf ()
@@ -247,8 +306,10 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
 The selected directory is projectile's root directory if projectile
 is used, otherwise the current working directory is used."
   (interactive)
-  (fzf/start (fzf/resolve-directory) #'fzf/action-find-file))
+  (let ((fzf-target-validator (function fzf--validate-filename)))
+    (fzf--start (fzf--resolve-directory) #'fzf--action-find-file)))
 
+;; Public utility
 (defun fzf-with-command (command action &optional directory as-filter initq)
   "Run `fzf` on the output of COMMAND.
 
@@ -279,10 +340,10 @@ reduce the search space, instead of using fzf to filter (but not narrow)."
                              fzf/grep-command
                              " {q} || true\"")
                    fzf/args)))
-        (fzf/start directory action args))
-    (fzf/start directory action)))
+        (fzf--start directory action args))
+    (fzf--start directory action)))
 
-;;;###autoload
+;; Public utility
 (defun fzf-with-entries (entries action &optional directory)
   "Run `fzf` with the list ENTRIES as input.
 
@@ -300,14 +361,16 @@ If DIRECTORY is specified, fzf is run from that directory."
 (defun fzf-directory ()
   "Starts a fzf session at the specified directory."
   (interactive)
-  (let ((d (read-directory-name "Directory: " fzf/directory-start)))
-    (fzf/start d
-               (lambda (x)
-                 (let ((f (expand-file-name x d)))
-                   (when (file-exists-p f)
-                     (find-file f)))))))
+  (let ((fzf-target-validator (function fzf--validate-filename))
+        (d (read-directory-name "Directory: " fzf/directory-start)))
+    (fzf--start d
+                (lambda (x)
+                  (let ((f (expand-file-name x d)))
+                    (when (file-exists-p f)
+                      (find-file f)))))))
 
-(defun fzf/resolve-directory (&optional directory)
+;; Internal helper function
+(defun fzf--resolve-directory (&optional directory)
   "Identify and return directory to perform fzf search.
 
 Return DIRECTORY if specified, the projectile project root if
@@ -317,7 +380,7 @@ Example usage:
 
   (defun fzf-example ()
     (fzf  (lambda (x) (print x))
-          (fzf/resolve-directory directory)))"
+          (fzf--resolve-directory directory)))"
   (cond
    (directory directory)
    ((fboundp 'projectile-project-root)
@@ -326,23 +389,24 @@ Example usage:
       (error default-directory)))
    (t default-directory)))
 
-
 ;;;###autoload
 (defun fzf-switch-buffer ()
   "Switch buffer selecting them with fzf."
   (interactive)
-  (fzf-with-entries
-   (seq-filter
-    (lambda (x) (not (string-prefix-p " " x)))
-    (mapcar (function buffer-name) (buffer-list)))
-   (lambda (x) (set-window-buffer nil x))))
+  (let ((fzf-target-validator (function fzf--pass-through)))
+    (fzf-with-entries
+     (seq-filter
+      (lambda (x) (not (string-prefix-p " " x)))
+      (mapcar (function buffer-name) (buffer-list)))
+     (lambda (x) (set-window-buffer nil x)))))
 
 ;;;###autoload
 (defun fzf-find-file (&optional directory)
   "Find file in projectile project (if used), current or specified DIRECTORY."
   (interactive)
-  (let ((d (fzf/resolve-directory directory)))
-    (fzf/start d
+  (let ((fzf-target-validator (function fzf--validate-filename))
+        (d (fzf--resolve-directory directory)))
+    (fzf--start d
                (lambda (x)
                  (let ((f (expand-file-name x d)))
                    (when (file-exists-p f)
@@ -361,32 +425,34 @@ Example usage:
   "Starts a fzf session based on git grep result. The input comes
    from the prompt or the selected region."
   (interactive)
-  (fzf-with-command (fzf/grep-cmd "git grep" fzf/git-grep-args)
-                    #'fzf/action-find-file-with-line
-                    (locate-dominating-file default-directory ".git")))
+  (let ((fzf-target-validator (function fzf--pass-through)))
+    (fzf-with-command (fzf--grep-cmd "git grep" fzf/git-grep-args)
+                      #'fzf--action-find-file-with-line
+                      (locate-dominating-file default-directory ".git"))))
 
 ;;;###autoload
 (defun fzf-recentf ()
   "Start a fzf session with the list of recently opened files."
   (interactive)
-  (if (bound-and-true-p recentf-list)
-      (fzf-with-entries recentf-list #'fzf/action-find-file)
-    (user-error "No recently opened files.%s"
-                (if (boundp 'recentf-list)
-                    ""
-                  " recentf-mode is not active!"))))
-
+  (let ((fzf-target-validator (function fzf--pass-through)))
+    (if (bound-and-true-p recentf-list)
+        (fzf-with-entries recentf-list #'fzf--action-find-file)
+      (user-error "No recently opened files.%s"
+                  (if (boundp 'recentf-list)
+                      ""
+                    " recentf-mode is not active!")))))
 
 ;;;###autoload
 (defun fzf-grep (&optional search directory as-filter)
   "Call `fzf/grep-command` on SEARCH.
 
 If SEARCH is nil, read input interactively.
-Grep in `fzf/resolve-directory` using DIRECTORY if provided.
+Grep in `fzf--resolve-directory` using DIRECTORY if provided.
 If AS-FILTER is non-nil, use grep as the narrowing filter instead of fzf."
   (interactive)
-  (let* ((dir (fzf/resolve-directory directory))
-         (action #'fzf/action-find-file-with-line)
+  (let* ((fzf-target-validator (function fzf--pass-through))
+         (dir (fzf--resolve-directory directory))
+         (action #'fzf--action-find-file-with-line)
          (pattern (or search
                       (read-from-minibuffer (concat fzf/grep-command ": "))))
          (cmd (concat fzf/grep-command " " pattern)))
@@ -439,27 +505,30 @@ If `thing-at-point` is not a symbol, read input interactively."
 (defun fzf-git ()
   "Starts an fzf session at the root of the current git project."
   (interactive)
-  (let ((path (locate-dominating-file default-directory ".git")))
+  (let ((fzf-target-validator (function fzf--validate-filename))
+        (path (locate-dominating-file default-directory ".git")))
     (if path
-        (fzf/start path #'fzf/action-find-file)
+        (fzf--start path #'fzf--action-find-file)
       (user-error "Not inside a Git repository"))))
 
 ;;;###autoload
 (defun fzf-hg ()
   "Starts an fzf session at the root of the current hg project."
   (interactive)
-  (let ((path (locate-dominating-file default-directory ".hg")))
+  (let ((fzf-target-validator (function fzf--validate-filename))
+        (path (locate-dominating-file default-directory ".hg")))
     (if path
-        (fzf/start path #'fzf/action-find-file)
+        (fzf--start path #'fzf--action-find-file)
       (user-error "Not inside a .hg repository"))))
 
 ;;;###autoload
 (defun fzf-git-files ()
   "Starts an fzf session for tracked files in the current git project."
   (interactive)
-  (let ((path (locate-dominating-file default-directory ".git")))
+  (let ((fzf-target-validator (function fzf--validate-filename))
+        (path (locate-dominating-file default-directory ".git")))
     (if path
-        (fzf-with-command "git ls-files" #'fzf/action-find-file path)
+        (fzf-with-command "git ls-files" #'fzf--action-find-file path)
       (user-error "Not inside a Git repository"))))
 
 ;;;###autoload
@@ -468,15 +537,22 @@ If `thing-at-point` is not a symbol, read input interactively."
   (interactive)
   (require 'projectile)
   (if (fboundp 'projectile-project-root)
-      (fzf/start (or (projectile-project-root) default-directory)
-                 #'fzf/action-find-file)
+      (let ((fzf-target-validator (function fzf--validate-filename)))
+        (fzf--start (or (projectile-project-root) default-directory)
+                    #'fzf--action-find-file))
     (error "projectile-project-root is not bound")))
 
-(defun fzf/test ()
-  (fzf-with-entries
-   (list "a" "b" "c")
-   (lambda (x) (print x))))
+;; ---------------------------------------------------------------------------
 
+;; test function
+(defun fzf/test ()
+  "Test ability to handle simple strings."
+  (let ((fzf-target-validator (function fzf--pass-through)))
+    (fzf-with-entries
+     (list "a" "b" "c")
+     (lambda (x) (print x)))))
+
+;; ---------------------------------------------------------------------------
 (provide 'fzf)
 
 ;;; fzf.el ends here


### PR DESCRIPTION
Fixes:

- https://github.com/bling/fzf.el/issues/84
- https://github.com/bling/fzf.el/issues/82

'fzf/after-term-handle-exit' now detect extra spaces or other characters at the end of the file name returned by extraction of fzf output.

This occurs since fzf 0.35.1 as reported by issue #82 because of a new separator line.  But instead of modifying the command line the function trims any whitespace at the end of the file name.  If the resulting file name is not found it tries to extract the correct file name by removing characters at the end until a valid filename is found.  If it does not find any valid file name it then issues a descriptive message to provide enough info for further improvements.

Also included fix for issue #87 as well as other cleanup:

The following functions are no longer interactive: they can't be used interactively:

- `fzf-with-command`
- `fzf-with-entries`

Also: `fzf-close` is no longer interactive. It really is an internal function.

Other fixes:

- Fix URL in `fzf-with-command` docstring.
- Restored original projectile error handling in `fzf/resolve-directory` while still
  preventing the byte-compiler warning.
- Added docstring to: `fzf-close`, `fzf/resolve-directory`, `fzf-switch-buffer`,
  `fzf-find-file`, `fzf-find-file-in-dir`.
- Improved docstring in `fzf`
- Cleanup lisp syntax in `fzf-close`, `fzf`, `fzf-with-entries`, `fzf-directory`,
  `fzf-switch-buffer`.