### PR TITLE
All commands user-error when fzf/executable not in PATH

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -240,6 +240,9 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
   ;; Clean up existing fzf, allowing multiple action types.
   (fzf--close)
 
+  (unless (executable-find fzf/executable)
+    (user-error "Can't find fzf/executable '%s'. Is it in your OS PATH?"
+                fzf/executable))
   ;; launch process in an inferior terminal mapped in current window
   (window-configuration-to-register fzf/window-register)
   (advice-add 'term-handle-exit


### PR DESCRIPTION
This addresses [issue #12](https://github.com/bling/fzf.el/issues/12) making user aware when Emacs can't access fzf executable instead of silently failing.