### PR TITLE
Fix regression on fzf grep command + minor improvements

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -321,7 +321,7 @@ DIRECTORY, if non-nil, is prepended to the result of fzf."
     (when (file-exists-p f)
       (find-file f)
       (goto-char (point-min))
-      (forward-line (string-to-number (nth 1 parts))))))
+      (forward-line (-  (string-to-number (nth 1 parts)) 1)))))
 
 ;;;###autoload
 (defun fzf ()

--- a/fzf.el
+++ b/fzf.el
@@ -451,16 +451,6 @@ Example usage:
     (fzf-find-file dir)))
 
 ;;;###autoload
-(defun fzf-git-grep ()
-  "Starts a fzf session based on git grep result. The input comes
-   from the prompt or the selected region."
-  (interactive)
-  (let ((fzf-target-validator (function fzf--pass-through)))
-    (fzf-with-command (fzf--grep-cmd "git grep" fzf/git-grep-args)
-                      #'fzf--action-find-file-with-line
-                      (locate-dominating-file default-directory ".git"))))
-
-;;;###autoload
 (defun fzf-recentf ()
   "Start a fzf session with the list of recently opened files."
   (interactive)
@@ -569,6 +559,15 @@ Only search files that have been committed."
   (interactive)
   (fzf--vcs-command "Git" ".git" "git ls-files"))
 
+;;;###autoload
+(defun fzf-git-grep ()
+  "Starts a fzf session based on git grep result. The input comes
+   from the prompt or the selected region."
+  (interactive)
+  (let ((fzf-target-validator (function fzf--pass-through)))
+    (fzf-with-command (fzf--grep-cmd "git grep" fzf/git-grep-args)
+                      #'fzf--action-find-file-with-line
+                      (locate-dominating-file default-directory ".git"))))
 ;;;###autoload
 (defun fzf-hg ()
   "Starts an fzf session at the root of the current hg repo.


### PR DESCRIPTION
- Fix regression in `fzf--action-find-file-with-line` introduced when changed code to use forward-line. The function moved to 1 line below the target. It now moves to the proper line.
-  Refactoring:
   - Rename `fzf/window-register` to `fzf--window-register`, since   the register is not meant to be used by user code.
   - Also clarified its docstring.
   - Clarified `fzf-grep` docstring.
- Regrouping: 
   - Move `fzf-git-grep` inside the VCS-related command code area.