### PR TITLE
Fix regression described in issue #91

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -556,18 +556,24 @@ reduce the search space, instead of using fzf to filter (but not narrow)."
     (fzf--start directory action)))
 
 ;; Public utility
-(defun fzf-with-entries (entries action &optional directory)
+(defun fzf-with-entries (entries action &optional directory validator)
   "Run `fzf` with the list ENTRIES as input.
 
 ACTION is a function that takes a single argument, which is the
 selected result from `fzf`.
-If DIRECTORY is specified, fzf is run from that directory."
-  (if entries
-      (fzf-with-command
-       (concat "echo \""
-               (mapconcat (lambda (x) x) entries "\n") "\"")
-       action directory)
-    (user-error "No input entries specified")))
+If DIRECTORY is specified, fzf is run from that directory.
+If VALIDATOR is specified it must be a function with the same signature as
+`fzf--validate-filename' and it will be used as a item validator. If VALIDATOR
+is nil, the default, then the `fzf--pass-through' validator is used (doing
+no validation."
+  (let ((fzf--target-validator (or validator
+                                   (function fzf--pass-through))))
+    (if entries
+        (fzf-with-command
+         (concat "echo \""
+                 (mapconcat (lambda (x) x) entries "\n") "\"")
+         action directory)
+      (user-error "No input entries specified"))))
 
 ;;;###autoload
 (defun fzf-directory ()


### PR DESCRIPTION
This addresses regression issue https://github.com/bling/fzf.el/issues/91 .

The problem was caused by `fzf-with-entries` using the file validator instead or the pass-through validator.  The new version of `fzf-with-entries` uses the pass-through validator by default and allows the user to specify another validator by a new optional argument.