### PR TITLE
Add fzf-find-in-buffer (by LiuYinCarl)

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -486,7 +486,7 @@ The returned lambda requires extra context information:
               (progn
                 (find-file fname)
                 (goto-char (point-min))
-                (forward-line (- line 1)))
+                (forward-line (1- line)))
             (error "Found non-existing file: '%s'" fname)))
       (error "Nothing matching! Is regexp ok?: '%s'" regexp))))
 
@@ -725,10 +725,15 @@ The same note applies here."
 (defun fzf-grep-dwim ()
   "Call `fzf-grep` on `symbol-at-point`.
 
-If `thing-at-point` is not a symbol, read input interactively.
+If there's no symbol at point (as identified by
+`thing-at-point'), prompt for one.
 
-See note about file & line extraction in `fzf-grep'.
-The same note applies here."
+See note about file & line extraction in `fzf-grep'.  The same
+note applies here.
+
+Current limitation: only works with search program that does not
+require a file pattern, like rg.  'grep -rnH' does not work
+here."
   (interactive)
   (if (symbol-at-point)
       (fzf-grep (thing-at-point 'symbol))
@@ -738,10 +743,15 @@ The same note applies here."
 (defun fzf-grep-dwim-with-narrowing ()
   "Call `fzf-grep` on `symbol-at-point`, with grep as the narrowing filter.
 
-If `thing-at-point` is not a symbol, read input interactively.
+If there's no symbol at point (as identified by
+`thing-at-point'), prompt for one.
 
-See note about file & line extraction in `fzf-grep'.
-The same note applies here."
+See note about file & line extraction in `fzf-grep'.  The same
+note applies here.
+
+Current limitation: only works with search program that does not
+require a file pattern, like rg.  'grep -rnH' does not work
+here."
   (interactive)
   (if (symbol-at-point)
       (fzf-grep (thing-at-point 'symbol) nil t)

--- a/fzf.el
+++ b/fzf.el
@@ -703,7 +703,7 @@ TARGET is a line produced by 'cat -n'."
                     " recentf-mode is not active!")))))
 
 ;;;###autoload
-(defun fzf-grep (&optional search directory as-filter)
+(defun fzf-grep (&optional search directory as-filter file-pattern)
   "FZF search filtered on a grep search result.
 
 - SEARCH is the end of the grep command line;  typically holding the regexp
@@ -732,7 +732,10 @@ File name & Line extraction:
          (action #'fzf--action-find-file-with-line)
          (pattern (or search
                       (read-from-minibuffer (concat fzf/grep-command ": "))))
-         (cmd (concat fzf/grep-command " " pattern))
+         (cmd (concat fzf/grep-command
+                      " "
+                      pattern
+                      file-pattern))
          (fzf--extractor-list (fzf--use-extractor
                                (list fzf--file-lnum-regexp 1 2))))
     (fzf-with-command cmd action dir as-filter pattern)))
@@ -783,9 +786,11 @@ Current limitation: only works with search program that does not
 require a file pattern, like rg.  'grep -rnH' does not work
 here."
   (interactive)
-  (if (symbol-at-point)
-      (fzf-grep (thing-at-point 'symbol))
-    (fzf-grep)))
+  (let ((file-pattern (when (string-match-p "^grep " fzf/grep-command)
+                        " *")))
+    (if (symbol-at-point)
+        (fzf-grep (thing-at-point 'symbol) nil nil file-pattern)
+      (fzf-grep nil nil file-pattern))))
 
 ;;;###autoload
 (defun fzf-grep-dwim-with-narrowing ()
@@ -801,9 +806,11 @@ Current limitation: only works with search program that does not
 require a file pattern, like rg.  'grep -rnH' does not work
 here."
   (interactive)
-  (if (symbol-at-point)
-      (fzf-grep (thing-at-point 'symbol) nil t)
-    (fzf-grep nil nil t)))
+  (let ((file-pattern (when (string-match-p "^grep " fzf/grep-command)
+                        " *")))
+    (if (symbol-at-point)
+        (fzf-grep (thing-at-point 'symbol) nil t file-pattern)
+      (fzf-grep nil nil t file-pattern))))
 
 ;; ---------------------------------------------------------------------------
 ;; VCS Support


### PR DESCRIPTION
Add fzf-find-in-buffer originally proposed by LiuYinCarl in https://github.com/bling/fzf.el/issues/94

- I modified the proposed code a little to adapt to the current code and added protection against trying to search in a buffer that is not visiting a file, an prompt to save the buffer if it has been modified.

Plus:

- Added a description of the limitations of the dwim commands when using grep.
- Small optimization:  ```(- v 1)``` --> ```(1- v)```