### PR TITLE
More flexible dwim grep with prompt history

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -476,7 +476,6 @@ The returned lambda requires extra context information:
   ;; Clean up existing fzf, allowing multiple action types.
   (fzf--close)
 
-  ;; (message "fzf--start %S %S %S" directory action custom-args)
   (unless (executable-find fzf/executable)
     (user-error "Can't find fzf/executable '%s'. Is it in your OS PATH?"
                 fzf/executable))
@@ -599,7 +598,6 @@ with INITQ as the initial query, as explained here:
 https://github.com/junegunn/fzf/blob/master/ADVANCED.md#using-fzf-as-interactive-ripgrep-launcher
 E.g. If COMMAND is grep, use grep as a narrowing filter to interactively
 reduce the search space, instead of using fzf to filter (but not narrow)."
-  ;; (message "fzf-with-command: %S %s %s %s %s %s" command action directory as-filter initq file-pattern)
   (if command
       (let
           ((process-environment (cons
@@ -790,7 +788,6 @@ File name & Line extraction:
     one dash after 'fzf'!  It's not the same as the internal
     `fzf--extractor-list' variable!"
   (interactive)
-  ;; (message "fzf-grep %S %S %S %S" search directory as-filter file-pattern)
   (let* ((fzf--target-validator (fzf--use-validator
                                  (function fzf--pass-through)))
          (dir (fzf--resolve-directory directory))
@@ -830,7 +827,6 @@ The same note applies here."
 See note about file & line extraction in `fzf-grep'.
 The same note applies here."
   (interactive "P")
-  ;; (message "fzf-grep-with-narrowing")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (fzf-grep nil nil t file-pattern)))
 
@@ -841,7 +837,6 @@ The same note applies here."
 See note about file & line extraction in `fzf-grep'.
 The same note applies here."
   (interactive "P")
-  ;; (message "fzf-grep-in-dir-with-narrowing")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (fzf-grep-in-dir nil t file-pattern)))
 
@@ -880,7 +875,6 @@ pattern to use.
 See note about file & line extraction in `fzf-grep'.  The same
 note applies here."
   (interactive "P")
-  ;; (message "fzf-grep-dwim-with-narrowing")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (if (symbol-at-point)
         (fzf-grep (thing-at-point 'symbol) nil t file-pattern)

--- a/fzf.el
+++ b/fzf.el
@@ -824,8 +824,13 @@ The same note applies here."
 (defun fzf-grep-with-narrowing (&optional with-file-pattern)
   "Call `fzf-grep` with grep as the narrowing filter.
 
-See note about file & line extraction in `fzf-grep'.
-The same note applies here."
+By default the grep command searches in the files identified by
+the `fzf/grep-file-pattern' user-option unless a
+WITH-FILE_PATTERN prefix argument argument is used; in that case
+it prompts for a file pattern to use. The prompt identifies the
+tool used (grep or rg) if it recognizes the on specified in
+`fzf/grep-command'.  Remember to use the file pattern appropriate
+for the tool; grep and Ripgrep use different ones."
   (interactive "P")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (fzf-grep nil nil t file-pattern)))
@@ -834,8 +839,14 @@ The same note applies here."
 (defun fzf-grep-in-dir-with-narrowing (&optional with-file-pattern)
   "Call `fzf-grep-in-dir` with grep as the narrowing filter.
 
-See note about file & line extraction in `fzf-grep'.
-The same note applies here."
+
+By default the grep command searches in the files identified by
+the `fzf/grep-file-pattern' user-option unless a
+WITH-FILE_PATTERN prefix argument argument is used; in that case
+it prompts for a file pattern to use. The prompt identifies the
+tool used (grep or rg) if it recognizes the on specified in
+`fzf/grep-command'.  Remember to use the file pattern appropriate
+for the tool; grep and Ripgrep use different ones."
   (interactive "P")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (fzf-grep-in-dir nil t file-pattern)))
@@ -848,12 +859,12 @@ If there's no symbol at point (as identified by
 `thing-at-point'), prompt for one.
 
 By default the grep command searches in the files identified by
-the `fzf/grep-file-pattern' user-option unless WITH-FILE_PATTERN
-prefix argument is used; in that case it prompts for a file
-pattern to use.
-
-See note about file & line extraction in `fzf-grep'.  The same
-note applies here."
+the `fzf/grep-file-pattern' user-option unless a
+WITH-FILE_PATTERN prefix argument argument is used; in that case
+it prompts for a file pattern to use. The prompt identifies the
+tool used (grep or rg) if it recognizes the on specified in
+`fzf/grep-command'.  Remember to use the file pattern appropriate
+for the tool; grep and Ripgrep use different ones."
   (interactive "P")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (if (symbol-at-point)

--- a/fzf.el
+++ b/fzf.el
@@ -826,13 +826,18 @@ The same note applies here."
 If there's no symbol at point (as identified by
 `thing-at-point'), prompt for one.
 
+By default the grep command searches in the files identified by
+the `fzf/grep-file-pattern' user-option unless WITH-FILE_PATTERN
+prefix argument is used; in that case it prompts for a file
+pattern to use.
+
 See note about file & line extraction in `fzf-grep'.  The same
 note applies here."
   (interactive "P")
   (let ((file-pattern (fzf--grep-file-pattern with-file-pattern)))
     (if (symbol-at-point)
         (fzf-grep (thing-at-point 'symbol) nil nil file-pattern)
-      (fzf-grep nil nil file-pattern))))
+      (fzf-grep nil nil nil file-pattern))))
 
 ;;;###autoload
 (defun fzf-grep-dwim-with-narrowing (&optional with-file-pattern)
@@ -840,6 +845,11 @@ note applies here."
 
 If there's no symbol at point (as identified by
 `thing-at-point'), prompt for one.
+
+By default the grep command searches in the files identified by
+the `fzf/grep-file-pattern' user-option unless WITH-FILE_PATTERN
+prefix argument is used; in that case it prompts for a file
+pattern to use.
 
 See note about file & line extraction in `fzf-grep'.  The same
 note applies here."


### PR DESCRIPTION
The `fzf-grep-dwim` and `fzf-grep-dwim-with-narrowing` commands can now be invoked with a command prefix, like C-u.  When that's done the commands prompt for the file pattern to use.  Otherwise they use the default file pattern identified by the new `fzf/grep-file-pattern` customizable user-option.

- All prompts for grep operations now have a prompt history which can be invoked during the minibuffer prompt operation with M-p and M-p.  By default the history is kept independent for each major mode. If you prefer a global prompt history, shared across all major modes, then set the new `fzf/prompt-history-per-major-mode` customizable user-option to nil.
- Removed the limitation notes in the grep dwim commands as they no longer apply.
-Add `:safe` attribute to the boolean user-options.

Fix narrowing grep fuzzy searches. More flexible narrowing commands.

This addresses issue https://github.com/bling/fzf.el/issues/98: it allows narrowing fzf searches to work with grep.

- It also adds the ability to invoke the grep narrowing commands with a prefix argument to get prompted for a file pattern.  The file pattern for grep and Ripgrep differ, so the prompt identifies the tool used (grep or rg) if it recognizes it, otherwise it just prompts for a file pattern.