### PR TITLE
More informative message on FZF selection.

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -492,7 +492,9 @@ The returned lambda requires extra context information:
       ;; Kill the fzf buffer and restore the previous window configuration.
       (kill-buffer fzf/buffer-name)
       (jump-to-register fzf--window-register)
-      (message (format "FZF exited with code %s" exit-code))
+      (if (string= exit-code "0")
+          (message "FZF selection: %s" target)
+        (user-error "FZF error: %s" exit-code))
       ;; Extract file/line from fzf only if fzf was successful.
       (when (string= "0" exit-code)
         ;; Re-Establish the fzf--extractor-list required by original caller


### PR DESCRIPTION
The current message simply shows "FZF exited with code 0" when FZF operation suceeded. This message might have been useful during debugging but it's not very useful for users.

That is replaced with the following:
- On success, message shows a description of what was actually selected; a file name (with full path), file name, line number and line text, or the line number and line text depending of the type of command executed.
- On error, a user-error shows the FZF error.

The success message is most useful when a user wants to remember what file was previously selected by the FZF operation.