### PR TITLE
Improve C-g, C-x C-c, enable C-x, fix warnings, reduce debugging messages, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,15 +118,15 @@ short summary where I used `/regular expressions/` to illustrate the matching be
 match is listed first*.
 
 
-| PATTERN     | MATCH RESULT                                                                                                                                   |
-|:------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `foo`       | Match file paths containing `/foo/`, `/f.*oo/`, `/f.*o.*o/`, etc.                                                                              |
-| `foo bar`   | Use spaces to specify multiple pattern terms, `foo bar` matches paths containing both terms, `/foo.*bar/`,  `/bar.*foo/`, `/f.*oo.*bar/`, etc. |
-| `'foo`      | File paths containing exactly the string foo (`/foo/`)                                                                                         |
-| `!foo`      | Negation, file paths that do not contain exact match, foo, in their name                                                                       |
-| `^foo/bar`  | An anchored match, a term prefixed with ^ means match files                                                                                    |
-| `.cpp$`     | An anchored match, a term postfixed with $ means match files ending with .cpp                                                                  |
-| `.c$ | .h$` | OR operator, match paths ending in .c or .h                                                                                                    |
+| PATTERN      | MATCH RESULT                                                                                                                                   |
+|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `foo`        | Match file paths containing `/foo/`, `/f.*oo/`, `/f.*o.*o/`, etc.                                                                              |
+| `foo bar`    | Use spaces to specify multiple pattern terms, `foo bar` matches paths containing both terms, `/foo.*bar/`,  `/bar.*foo/`, `/f.*oo.*bar/`, etc. |
+| `'foo`       | File paths containing exactly the string foo (`/foo/`)                                                                                         |
+| `!foo`       | Negation, file paths that do not contain exact match, foo, in their name                                                                       |
+| `^foo/bar`   | An anchored match, a term prefixed with ^ means match files starting with foo/bar                                                              |
+| `.cpp$`      | An anchored match, a term postfixed with $ means match files ending with .cpp                                                                  |
+| `.c$ \| .h$` | OR operator, match paths ending in .c or .h                                                                                                    |
 
 For example, the pattern "`^apps/special 'foo !bar .c$ | .h$`" will match file paths starting with "apps/special"
 that contain the string "foo", not the string "bar", and end in ".c" or ".h".

--- a/README.md
+++ b/README.md
@@ -97,6 +97,48 @@ Or more exciting:
     d)))
 ```
 
+## Interacting with the FZF buffer
+
+When you run one of the above commands, you will see an "FZF" buffer. For example, when
+using `M-x fzf`, you'll see a buffer that looks like:
+
+```
+ file1.ext
+ file2.ext
+ file3.ext
+ ....
+ > SELECTED-FILE            # RET (Enter) will open this file
+ 1580404/1580404            # Fuzzy find on my 1.6 million files
+ > PATTERN                  # You type a fuzzy pattern to find
+```
+The *PATTERN* you type will narrow the selected items. PATTERN is used to do
+[approximate string matching](https://en.wikipedia.org/wiki/Approximate_string_matching).
+The PATTERN syntax is described in the [fzf man page](https://www.mankier.com/1/fzf) and is not a regular expression. Below is a
+short summary where I used `/regular expressions/` to illustrate the matching behavior. *The closest
+match is listed first*.
+
+
+| PATTERN     | MATCH RESULT                                                                                                                                   |
+|:------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| `foo`       | Match file paths containing `/foo/`, `/f.*oo/`, `/f.*o.*o/`, etc.                                                                              |
+| `foo bar`   | Use spaces to specify multiple pattern terms, `foo bar` matches paths containing both terms, `/foo.*bar/`,  `/bar.*foo/`, `/f.*oo.*bar/`, etc. |
+| `'foo`      | File paths containing exactly the string foo (`/foo/`)                                                                                         |
+| `!foo`      | Negation, file paths that do not contain exact match, foo, in their name                                                                       |
+| `^foo/bar`  | An anchored match, a term prefixed with ^ means match files                                                                                    |
+| `.cpp$`     | An anchored match, a term postfixed with $ means match files ending with .cpp                                                                  |
+| `.c$ | .h$` | OR operator, match paths ending in .c or .h                                                                                                    |
+
+For example, the pattern "`^apps/special 'foo !bar .c$ | .h$`" will match file paths starting with "apps/special"
+that contain the string "foo", not the string "bar", and end in ".c" or ".h".
+
+**Keys**
+
+The FZF buffer which you use to fuzzy find is based on the underlying code for `M-x ansi-term`. Most
+keys you type are sent to the fzf process. We've set the terminal escape key to `C-x`. Use `C-x C-h`
+to see the key bindings in the FZF buffer. For example, you can maximize the FZF buffer window using
+`C-x 1` which closes the other windows in your Emacs frame thus giving you bigger FZF buffer window
+for fuzzy finding.
+
 # license
 
 GPL3

--- a/fzf.el
+++ b/fzf.el
@@ -177,9 +177,18 @@ write the absolute path of the executable to use."
 
 (defcustom fzf/args (concat
                      "-x "
-                     (if (eq (frame-parameter nil 'background-mode) 'light)
-                         "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:1,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 "
-                       "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:6,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 ")
+                     (cond
+                      ((display-graphic-p)
+                       (cond
+                        ((eq (frame-parameter nil 'background-mode) 'light)
+                         ;; Windowing system, light background
+                         "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:1,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 ")
+                        (t
+                         ;; Windowing system, dark background
+                         "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:6,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 ")))
+                      (t
+                       ;; In terminal, can't tell if in a light or dark background
+                       "--color=16,fg:-1,fg+:0,bg:-1,bg+:-1,hl:1,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 "))
                      "--print-query --margin=1,0 --no-hscroll")
   "Additional arguments to pass into fzf."
   :type 'string

--- a/fzf.el
+++ b/fzf.el
@@ -130,7 +130,57 @@ write the absolute path of the executable to use."
   :type 'string
   :group 'fzf)
 
-(defcustom fzf/args "-x --color bw --print-query --margin=1,0 --no-hscroll"
+;; fzf/args:
+;;   term.el which fzf uses requires 16-bit colors or you can use black and white
+;;   which is specified via fzf --color=bw.
+;;
+;;   To specify fzf colors use
+;;     --color=16[,COLOR:ANSI_CODE,....]
+;;
+;;   COLOR                     Description
+;;   ------------------------- --------------------------------------------------
+;;   fg / bg / hl              Item (foreground / background / highlight)
+;;   fg+ / bg+ / hl+           Current item (foreground / background / highlight)
+;;   preview-fg / preview-bg   Preview window text and background
+;;   hl / hl+                  Highlighted substrings (normal / current)
+;;   gutter                    Background of the gutter on the left
+;;   pointer                   Pointer to the current line (>)
+;;   marker                    Multi-select marker (>)
+;;   border                    Border around the window (--border and --preview)
+;;   header                    Header (--header or --header-lines)
+;;   info                      Info line (match counters)
+;;   spinner                   Streaming input indicator
+;;   query                     Query string
+;;   disabled                  Query string when search is disabled
+;;   prompt                    Prompt before query (> )
+;;   pointer                   Pointer to the current line (>)
+;;
+;;   ANSI_CODE (in Emacs 27 term.el, we are restricted to these colors):
+;;     0  black
+;;     1  red
+;;     2  green
+;;     3  yellow
+;;     4  blue
+;;     5  magenta
+;;     6  cyan
+;;     7  white
+;;
+;;   A color code of -1, denotes terminal default foreground/background color
+;;
+;;   See:
+;;     1) https://github.com/junegunn/fzf/wiki/Color-schemes
+;;     2) https://minsw.github.io/fzf-color-picker/
+;;     4) Alternate Solarized Light/Dark Theme (256 colors)
+;;        https://github.com/junegunn/fzf/wiki/Color-schemes#alternate-solarized-lightdark-theme
+;;     3) https://www.ditig.com/256-colors-cheat-sheet
+;;        The 256 color codes which help in converting to 16-bit codes
+
+(defcustom fzf/args (concat
+                     "-x "
+                     (if (eq (frame-parameter nil 'background-mode) 'light)
+                         "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:1,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 "
+                       "--color=16,fg:-1,fg+:0,bg:-1,bg+:3,hl:6,hl+:1,info:5,gutter:-1,prompt:5,pointer:4,marker:4,spinner:6 ")
+                     "--print-query --margin=1,0 --no-hscroll")
   "Additional arguments to pass into fzf."
   :type 'string
   :group 'fzf)


### PR DESCRIPTION
1. C-g in the FZF buffer results in exit code of 130. This is now handled and C-g gracefully removes FZF without error messages showing up.

2. An exit code of 1 from fzf isn't an error, that's when there's no input and now we don't see an error for this case.

3. C-x C-c was causing an "active process exist" prompt when the FZF buffer was present. Now if you exit while FZF buffer is present you don't get prompted.

5. Make C-x the terminal escape character. This means the key bindings behave similar to M-x ansi-term and thus you can use C-x 1 to maximize, etc.

6. The package used to state it required Emacs 24. However, it would not work in Emacs 24 because of the use of seq-filter. The package requires Emacs 25 and later, so I updated Package-Requires. I tested on Emacs 25, 26, 27 as we use all of these.

7. Fixed a couple compile warnings. Now this compiles warning free on Emacs 25, 26, 27.

8. Reduced debugging messages. "FZF blah" messages where showing up in *Messages* buffer even when there was success. I put these under an `fzf-show-debug-messages` variable thus reducing noise in *Messages*.

9. Added 'Interacting with the FZF buffer' to the readme.