### PR TITLE
Resolve symlinks in the base vcs command

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -980,19 +980,20 @@ note applies here."
 ;; Internal helper function
 (defun fzf--vcs (vcs-name root-filename)
   "Run FZF in the VCS-NAME directory holding ROOT-FILENAME."
-  (let ((fzf--target-validator (fzf--use-validator
-                                (function fzf--validate-filename)))
-        (path (locate-dominating-file default-directory root-filename)))
+  (let* ((fzf--target-validator (fzf--use-validator
+                                 (function fzf--validate-filename)))
+         (current-directory (file-truename default-directory)) ;; resolve symlinks
+         (path (locate-dominating-file current-directory root-filename)))
     (if path
         (fzf--start path (function fzf--action-find-file))
       (user-error "Not inside a %s repository" vcs-name))))
 
 (defun fzf--vcs-command (vcs-name root-filename command)
   "Run FZF specific COMMAND in the VCS-NAME directory holding ROOT-FILENAME."
-  (let ((fzf--target-validator (fzf--use-validator
-                                (function fzf--validate-filename)))
-        (current-directory (file-truename default-directory)) ;; Resolve symlinks
-        (path (locate-dominating-file current-directory root-filename)))
+  (let* ((fzf--target-validator (fzf--use-validator
+                                 (function fzf--validate-filename)))
+         (current-directory (file-truename default-directory)) ;; resolve symlinks
+         (path (locate-dominating-file current-directory root-filename)))
     (if path
         (fzf-with-command command (function fzf--action-find-file) path)
       (user-error "Not inside a %s repository" vcs-name))))

--- a/fzf.el
+++ b/fzf.el
@@ -991,7 +991,8 @@ note applies here."
   "Run FZF specific COMMAND in the VCS-NAME directory holding ROOT-FILENAME."
   (let ((fzf--target-validator (fzf--use-validator
                                 (function fzf--validate-filename)))
-        (path (locate-dominating-file default-directory root-filename)))
+        (current-directory (file-truename default-directory)) ;; Resolve symlinks
+        (path (locate-dominating-file current-directory root-filename)))
     (if path
         (fzf-with-command command (function fzf--action-find-file) path)
       (user-error "Not inside a %s repository" vcs-name))))


### PR DESCRIPTION
Modified the code to determine the true root directory. 
By using `file-truename` on `default-directory`, we resolve any symlinks, 
ensuring we get the actual physical location even if we're currently within a symlinked directory.

Example Scenario:
1. Dotfiles are version-controlled in the '~/sync' directory.
2. A symlink '~/.emacs.d' is created from '~/sync/.../emacs-configuration'.
3. If the `default-directory` is set under '~/.emacs.d', the original function fails to find the project root, as it doesn't resolve the symlink and searches within the symbolic link's hierarchy.

This patch fixes this behavior by ensuring we search the actual physical location by resolving any symlinks with `file-truename`.
