### PR TITLE
Add `fzf/position-bottom-of-frame` option and variable watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ available customizations and their default values.
         fzf/grep-command "grep -nrH"
         ;; If nil, the fzf buffer will appear at the top of the window
         fzf/position-bottom t
+        ;; If t, the fzf buffer will appear at the bottom of the frame
+        fzf/position-bottom nil
         fzf/window-height 15))
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ available customizations and their default values.
         ;; If nil, the fzf buffer will appear at the top of the window
         fzf/position-bottom t
         ;; If t, the fzf buffer will appear at the bottom of the frame
-        fzf/position-bottom nil
+        fzf/position-bottom-of-frame nil
         fzf/window-height 15))
 ```
 

--- a/fzf.el
+++ b/fzf.el
@@ -250,19 +250,6 @@ If nil, fzf prompts have the same history in all modes."
   :safe #'booleanp
   :group 'fzf)
 
-(defun fzf/position-bottom-of-frame-watcher (symbol newval operation where)
-  "Watcher function for `fzf/position-bottom-of-frame`.
-Updates settings for displaying fzf at the bottom of the Emacs frame."
-  (if newval
-      (add-to-list 'display-buffer-alist
-                   `("\\*fzf\\*"
-                     display-buffer-at-bottom
-                     (window-height . ,fzf/window-height)))
-    (setq display-buffer-alist
-          (assq-delete-all "\\*fzf\\*" display-buffer-alist))))
-
-(add-variable-watcher 'fzf/position-bottom-of-frame #'fzf/position-bottom-of-frame-watcher)
-
 (defconst fzf/buffer-name "*fzf*"
   "The name of the fzf buffer")
 
@@ -360,6 +347,21 @@ including file names with embedded colons.
 See `fzf--file-lnum-regexp' and `fzf--file-rnum-lnum-regexp' as examples.")
 
 ;; ---------------------------------------------------------------------------
+
+;; Internal helper function
+(defun fzf--position-bottom-of-frame-watcher (_symbol newval _operation _where)
+  "Watcher function for `fzf/position-bottom-of-frame'.
+Updates settings for displaying fzf at the bottom of the Emacs frame."
+  (if newval
+      (add-to-list 'display-buffer-alist
+                   `("\\*fzf\\*"
+                     display-buffer-at-bottom
+                     (window-height . ,fzf/window-height)))
+    (setq display-buffer-alist
+          (assq-delete-all "\\*fzf\\*" display-buffer-alist))))
+
+(add-variable-watcher 'fzf/position-bottom-of-frame #'fzf--position-bottom-of-frame-watcher)
+
 ;; Internal helper function
 (defun fzf--read-for (operation prompt)
   "Prompt in minibuffer for OPERATION with PROMPT and history. Return entry.

--- a/fzf.el
+++ b/fzf.el
@@ -350,8 +350,8 @@ See `fzf--file-lnum-regexp' and `fzf--file-rnum-lnum-regexp' as examples.")
 
 ;; Internal helper function
 (defun fzf--position-bottom-of-frame-watcher (_symbol newval _operation _where)
-  "Watcher function for `fzf/position-bottom-of-frame'.
-Updates settings for displaying fzf at the bottom of the Emacs frame."
+  "Watch for changes of `fzf/position-bottom-of-frame'.
+Update settings for displaying fzf at the bottom of the Emacs frame."
   (if newval
       (add-to-list 'display-buffer-alist
                    `("\\*fzf\\*"


### PR DESCRIPTION
Hi, this PR introduces the `fzf/position-bottom-of-frame` variable to let users configure `fzf.el` to behave similar to `find-file` - always open the selection buffer at the bottom of the Emacs frame.

Implemented thanks to @jcfk's comment under #121.

Please bear in mind, this is my first ever contribution to an Emacs package.