### PR TITLE
fzf-switch-buffer: default to most-recently-used other buffer

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -773,7 +773,7 @@ Example usage:
     (fzf-with-entries
      (seq-filter
       (lambda (x) (not (string-prefix-p " " x)))
-      (mapcar (function buffer-name) (buffer-list)))
+      (mapcar (function buffer-name) (remove (current-buffer) (buffer-list))))
      (lambda (x) (set-window-buffer nil x)))))
 
 


### PR DESCRIPTION
Previously, the default buffer for `fzf-switch-buffer` was the *current* buffer, which doesn't seem like a useful thing to "switch" to.

Vanilla `switch-buffer` has the useful property that a bare `RET` response switches to the most-recently-used-before-the-current-buffer buffer. This commit makes `fzf-switch-buffer` behave the same way by removing the current buffer from the entries list.