### PR TITLE
Update package headers

### DIFF
--- a/fzf.el
+++ b/fzf.el
@@ -9,26 +9,26 @@
 ;; Version: 0.0.2
 ;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: fzf fuzzy search
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 3, or
 ;; (at your option) any later version.
-;;
+
 ;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 ;; General Public License for more details.
-;;
+
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program; see the file COPYING. If not, write to
 ;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
 ;; Floor, Boston, MA 02110-1301, USA.
-;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
+
+;;; Commentary:
+
 ;; Install:
 ;;
 ;; Autoloads will be set up automatically if you use package.el.


### PR DESCRIPTION
Mark the commentary section with its appropriate header so that it can be show by `describe-package`. The section is used as the package description when describing a package. ej. `C-h P fzf` currently shows:

> This package does not provide a description.

See `(info "(elisp)Simple packages")`

Also, add a blank line between sections to follow the [Conventional Headers for Emacs Libraries]

> We use additional stylized comments to subdivide the contents of the
> library file. These should be separated from anything else by blank
> lines. Here is a table of them:

[Conventional Headers for Emacs Libraries]: https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html